### PR TITLE
use demo data in test-4-analyze

### DIFF
--- a/R/run_aggregate_alignment_metric.R
+++ b/R/run_aggregate_alignment_metric.R
@@ -51,11 +51,20 @@ run_aggregate_alignment_metric <- function(config) {
   assert_inherits(time_frame, "integer")
 
   # load input data----
-  region_isos_select <- r2dii.data::region_isos %>%
-    dplyr::filter(
-      .data[["source"]] == .env[["scenario_source_input"]],
-      .data[["region"]] %in% .env[["region_select"]]
-    )
+  # if demo data is expected, use the region_isos_demo data set from r2dii.data
+  if (scenario_source_input %in% unique(r2dii.data::region_isos_demo$source)) {
+    region_isos_select <- r2dii.data::region_isos_demo %>%
+      dplyr::filter(
+        .data[["source"]] == .env[["scenario_source_input"]],
+        .data[["region"]] %in% .env[["region_select"]]
+      )
+  } else {
+    region_isos_select <- r2dii.data::region_isos %>%
+      dplyr::filter(
+        .data[["source"]] == .env[["scenario_source_input"]],
+        .data[["region"]] %in% .env[["region_select"]]
+      )
+  }
 
   scenario_input_tms <- readr::read_csv(
     path_scenario_tms,

--- a/R/run_pacta.R
+++ b/R/run_pacta.R
@@ -66,11 +66,20 @@ run_pacta <- function(config) {
   assert_inherits(time_frame_select, "integer")
 
   # load input data----
-  region_isos_select <- r2dii.data::region_isos %>%
-    dplyr::filter(
-      .data[["source"]] == .env[["scenario_source_input"]],
-      .data[["region"]] %in% .env[["region_select"]]
-    )
+  # if demo data is expected, use the region_isos_demo data set from r2dii.data
+  if (scenario_source_input %in% unique(r2dii.data::region_isos_demo$source)) {
+    region_isos_select <- r2dii.data::region_isos_demo %>%
+      dplyr::filter(
+        .data[["source"]] == .env[["scenario_source_input"]],
+        .data[["region"]] %in% .env[["region_select"]]
+      )
+  } else {
+    region_isos_select <- r2dii.data::region_isos %>%
+      dplyr::filter(
+        .data[["source"]] == .env[["scenario_source_input"]],
+        .data[["region"]] %in% .env[["region_select"]]
+      )
+  }
 
   scenario_input_tms <- readr::read_csv(
     path_scenario_tms,

--- a/tests/testthat/test-4-analyse.R
+++ b/tests/testthat/test-4-analyse.R
@@ -15,10 +15,13 @@ test_that("with known input, runs without error", {
         sheet_abcd = "Company Indicators - PACTA Comp"
       ),
       project_parameters = list(
-        scenario_source = "weo_2022",
-        scenario_select = "nze_2050",
+        scenario_source = "demo_2020",
+        scenario_select = "sds",
+        # scenario_source = "weo_2022",
+        # scenario_select = "nze_2050",
         region_select = "global",
-        start_year = 2022L,
+        start_year = 2020L,
+        # start_year = 2022L,
         time_frame = 5L,
         by_group = "group_id"
       ),


### PR DESCRIPTION
this is an extension of https://github.com/RMI-PACTA/pacta.multi.loanbook/pull/337

I attempt to actually use the demo data in test-4-analyze by changing the test config accordingly.
The code checks if the config uses the demo_2020 scenario source and if so, it will load the demo data from for regional matching from r2dii.data.

This is still not functional, because there is no common scenario name available in r2dii.data::r2dii.data::scenario_demo_2020 and in r2dii.data::r2dii.data::co2_intensity_scenario_demo, so there is no option of passing the "correct" scenario name in the test config..

fyi @cjyetman  @jdhoffa 