### PR TITLE
Add archive notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 # pacta.multi.loanbook <a href="https://rmi-pacta.github.io/pacta.multi.loanbook/"><img src="man/figures/logo.png" align="right" height="31" /></a>
 
+[![Project Status: Unsupported](https://www.repostatus.org/badges/latest/unsupported.svg)](https://www.repostatus.org/#unsupported)
+
+**This project is archived for future reference, but no new work is expected in this repository.**
+
 <!-- badges: start -->
 
 [![Lifecycle:


### PR DESCRIPTION
This PR marks the repository as archived in the README by adding the unsupported badge and archive notice under the main header.